### PR TITLE
Update Shadcn-vue subName and fix Reka UI repoName and package links

### DIFF
--- a/data/libraries.ts
+++ b/data/libraries.ts
@@ -268,9 +268,9 @@ export const libraries: Array<Library> = [
     name: "Reka UI",
     logo: "radixvue.svg",
     url: "https://reka-ui.com/",
-    repoOwner: "radix-vue",
-    repoName: "radix-vue",
-    package: "radix-vue",
+    repoOwner: "reka-ui",
+    repoName: "reka-ui",
+    package: "reka-ui",
     componentMatchings: [
       "Accordion",
       "Modal", // Alert Dialog

--- a/data/libraries.ts
+++ b/data/libraries.ts
@@ -313,7 +313,7 @@ export const libraries: Array<Library> = [
   },
   {
     name: "Shadcn-vue",
-    subName: "on top of Radix Vue",
+    subName: "on top of Reka-ui",
     logo: "shadcn.png",
     url: "https://www.shadcn-vue.com",
     repoOwner: "radix-vue",

--- a/data/libraries.ts
+++ b/data/libraries.ts
@@ -268,7 +268,7 @@ export const libraries: Array<Library> = [
     name: "Reka UI",
     logo: "radixvue.svg",
     url: "https://reka-ui.com/",
-    repoOwner: "reka-ui",
+    repoOwner: "unovue",
     repoName: "reka-ui",
     package: "reka-ui",
     componentMatchings: [
@@ -316,7 +316,7 @@ export const libraries: Array<Library> = [
     subName: "on top of Reka-ui",
     logo: "shadcn.png",
     url: "https://www.shadcn-vue.com",
-    repoOwner: "radix-vue",
+    repoOwner: "unovue",
     repoName: "shadcn-vue",
     package: "shadcn-vue",
     componentMatchings: [


### PR DESCRIPTION
1. Shadcn-vue now works on top of reka-ui instead of radix-vue. Here are the details https://github.com/unovue/shadcn-vue/releases/tag/v1.0.0 . 
2. I have updated the links to GitHub and npm for reka-ui, as the previous links pointed to GitHub and npm for radix-vue.